### PR TITLE
Remove &&

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "setting environments for node application",
   "main": "server.js",
   "scripts": {
-    "dev": "set NODE_ENV=development&& node server.js",
-    "prod": "set NODE_ENV=production&& node server.js"
+    "dev": "set NODE_ENV=development node server.js",
+    "prod": "set NODE_ENV=production node server.js"
   },
   "author": "Rahil Hussain Shaikh",
   "license": "ISC",


### PR DESCRIPTION
Not sure if this is specific to some environments, but I am proposing this small change because on my system (macOS, node 16), using && in package.json clears the environment variable, which means it will always default to development.